### PR TITLE
Add Custom Gradient Editor 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -498,17 +498,26 @@
 		<a href="#!" title="Close" class="modal-close"></a>
 		<div>
 			<a href="#!" title="Close" class="modal-close-internal"></a>
-			<div>
-				<span class="config-label"><label for="new-gradient-name">Name</label></span><br>
-				<input type="text" id="new-gradient-name">
-			</div>
+			<div><span class="config-label"><label for="new-gradient-name">Name</label></span></div>
+			<div class="mt-5px"><input type="text" id="new-gradient-name"></div>
 			<div class="mt-1">
-				<span class="config-label"><label for="new-gradient-colors">Colors</label></span><br>
 				<table id="grad-color-table">
+					<tr>
+						<td><span class="config-label">Colors</span></td>
+						<td></td>
+						<td><span class="config-label">Offset</span></td>
+					</tr>
 				</table>
-				<input type="checkbox" id="new-gradient-horizontal">
-				<label for="new-gradient-horizontal">Horizontal</label>
+				<div class="mt-5px">
+					<input type="checkbox" id="new-gradient-horizontal">
+					<label for="new-gradient-horizontal">Horizontal</label>
+				</div>
 				<table id="grad-color-table-template">
+					<tr id="grad-row-label-template">
+						<td><span class="config-label">Colors</span></td>
+						<td></td>
+						<td><span class="config-label">Offset</span></td>
+					</tr>
 					<tr id="grad-row-template" class="grad-color-row">
 						<td><input class="grad-color-picker" type="color"></td>
 						<td><input class="grad-color-value" type="text" size="10" pattern="^#[0-9A-Fa-f]{0,6}$"></td>
@@ -518,10 +527,8 @@
 					</tr>
 				</table>
 			</div>
-			<div class="mt-1">
-				<span class="config-label"><label for="new-gradient-bkgd">Background Color</label></span><br>
-				<input type="color" id="new-gradient-bkgd">
-			</div>
+			<div class="mt-1"><span class="config-label"><label for="new-gradient-bkgd">Background Color</label></span></div>
+			<div class="mt-5px"><input type="color" id="new-gradient-bkgd"></div>
 			<div class="flex align-center mt-1">
 				<button id="btn-delete-gradient">Delete</button>
 				<div></div>

--- a/public/index.html
+++ b/public/index.html
@@ -434,6 +434,7 @@
 				<h3>Enabled Gradients:</h3>
 				<div id="enabled_gradients" class="grid grid-3-cols">
 				</div>
+				<button class="button mt-1" id="add-gradient">Add Gradient</button>
 			</div>
 			<div>
 				<h3>Enabled BG Image Fit options:</h3>
@@ -492,6 +493,42 @@
 			</div>
 		</div>
 	</div> <!-- #config -->
+
+	<div id="gradient-editor" class="modal-window">
+		<a href="#!" title="Close" class="modal-close"></a>
+		<div>
+			<a href="#!" title="Close" class="modal-close-internal"></a>
+			<div>
+				<span class="config-label"><label for="new-gradient-name">Name</label></span><br>
+				<input type="text" id="new-gradient-name">
+			</div>
+			<div class="mt-1">
+				<span class="config-label"><label for="new-gradient-colors">Colors</label></span><br>
+				<table id="grad-color-table">
+				</table>
+				<input type="checkbox" id="new-gradient-horizontal">
+				<label for="new-gradient-horizontal">Horizontal</label>
+				<table id="grad-color-table-template">
+					<tr id="grad-row-template" class="grad-color-row">
+						<td><input class="grad-color-picker" type="color"></td>
+						<td><input class="grad-color-value" type="text" size="10" pattern="^#[0-9A-Fa-f]{0,6}$"></td>
+						<td><input class="grad-color-stop" type="text" size="5"></td>
+						<td><button class="grad-remove-stop"></button></td>
+						<td><button class="grad-add-stop"></button></td>
+					</tr>
+				</table>
+			</div>
+			<div class="mt-1">
+				<span class="config-label"><label for="new-gradient-bkgd">Background Color</label></span><br>
+				<input type="color" id="new-gradient-bkgd">
+			</div>
+			<div class="flex align-center mt-1">
+				<button id="btn-delete-gradient">Delete</button>
+				<div></div>
+				<button id="btn-save-gradient">Add</button>
+			</div>
+		</div>
+	</div> <!-- #gradient-editor -->
 
 	<div id="console">
 		<div id="console-clear">Clear</div>

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ const DATASET_TEMPLATE = {
 };
 
 // localStorage keys
-const KEY_CUSTOM_GRADS   = 'customgrads',
+const KEY_CUSTOM_GRADS   = 'custom-grads',
 	  KEY_CUSTOM_PRESET  = 'custom-preset',
 	  KEY_DISABLED_BGFIT = 'disabled-bgfit',
 	  KEY_DISABLED_GRADS = 'disabled-gradients',
@@ -299,9 +299,6 @@ const gradients = {
 			  ], disabled: false }
 };
 
-// gradient that is currently loaded in gradient editor
-let currentGradient = null;
-
 // Visualization modes
 const modeOptions = [
 	{ value: '0',   text: 'Discrete frequencies', disabled: false },
@@ -388,6 +385,7 @@ let audioElement = [],
 	bgVideos = [],
 	canvasMsg,
 	currAudio, 					// audio element currently in use
+	currentGradient = null,     // gradient that is currently loaded in gradient editor
 	fastSearchTimeout,
 	folderImages = {}, 			// folder cover images for songs with no picture in the metadata
 	isFastSearch = false,
@@ -1598,7 +1596,6 @@ function openGradientEdit(key) {
  */
 function openGradientEditorNew() {
 	currentGradient = {
-		dir: 'v',
 		name: 'New Gradient',
 		bgColor: '#111111',
 		colorStops: [
@@ -2736,7 +2733,7 @@ function setUIEventListeners() {
 	});
 
 	$('#new-gradient-horizontal').addEventListener('input', (e) => {
-		currentGradient.dir = e.target.checked ? 'h' : 'v';
+		currentGradient.dir = e.target.checked ? 'h' : undefined;
 	})
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1855,6 +1855,10 @@ function renderGradientEditor() {
 	// set horizontal
 	$('#new-gradient-horizontal').checked = currentGradient.dir === 'h';
 
+	const tableLabels = $('#grad-row-label-template').cloneNode(true);
+	tableLabels.removeAttribute("id");
+	table.appendChild(tableLabels);
+
 	// build row for each stop in the gradient
 	currentGradient.colorStops.forEach((stop, i) => {
 		renderColorRow(i, currentGradient.colorStops[i]);

--- a/src/styles.css
+++ b/src/styles.css
@@ -27,7 +27,7 @@ audio {
 
 select,
 input[type="text"] {
-	padding: 4px 0;
+	padding: 4px;
 }
 input[type="number"] {
 	margin: 2px 0;
@@ -37,6 +37,7 @@ input[type="number"] {
 
 button,
 .button {
+	cursor: pointer;
 	background: #f3f3f3;
 	border: 1px solid #adadad;
 	border-radius: 999px;
@@ -98,6 +99,16 @@ table {
 .button {
 	display: inline-block;
 	text-align: center;
+}
+
+/* remove link styling from links that should look like buttons */
+a.button {
+	color: black;
+	text-decoration: none;
+}
+
+a.button:visited {
+	color: black;
 }
 
 .thin-button {
@@ -1103,6 +1114,61 @@ input.slider:not(:checked) + .slider .slider-on {
 	transform-origin: -100% 50%;
 	width: 25%;
 }
+
+/* Color gradient editor */
+.mt-1 {
+	margin-top: 1rem;
+}
+
+.grad-color-row td {
+	padding: 5px 10px 5px 0
+}
+
+.grad-color-row td:last-child {
+	padding: 5px 0 5px;
+}
+
+.grad-add-stop, .grad-remove-stop {
+	border: none;
+	background: #444;
+	color: #fff;
+	padding: 0;
+	border-radius: 10px;
+	text-align: center;
+	height: 35px;
+	width: 35px;
+}
+
+button.grad-remove-stop[disabled] {
+	opacity: 0.8;
+}
+
+button.grad-remove-stop:hover:not([disabled]) {
+	border: none;
+	background-color: #c00 !important;
+}
+
+button.grad-add-stop:hover {
+	border: none;
+	background-color: #34a800 !important;
+}
+
+.grad-add-stop::before {
+	content: '\FF0B';
+}
+
+.grad-remove-stop::before {
+	content: '\2212';
+}
+
+.grad-color-value, .grad-color-stop {
+	text-align: center;
+}
+
+#grad-color-table-template {
+	display: none;
+}
+
 
 /**
  * Warp Tunnel effect

--- a/src/styles.css
+++ b/src/styles.css
@@ -1120,8 +1120,16 @@ input.slider:not(:checked) + .slider .slider-on {
 	margin-top: 1rem;
 }
 
+.mt-5px {
+	margin-top: 5px;
+}
+
 .grad-color-row td {
 	padding: 5px 10px 5px 0
+}
+
+.grad-color-row td:first-child {
+	padding: 5px 5px 5px 0;
 }
 
 .grad-color-row td:last-child {


### PR DESCRIPTION
This pull request merges changes for the custom gradient editor into the current state of `dev` branch.

Additionally, "Offset" was added as a label to the color position column in the editor.

<img width="1440" alt="Screen Shot 2021-11-11 at 8 59 52 PM" src="https://user-images.githubusercontent.com/3422979/141401753-af6a8e3d-d177-43bf-af1d-1fefb7c78df7.png">

I have not committed changes to build artifacts.


## Original PR description

This PR implements functionality to create new gradients for the analyzer.

For an overview of what this feature looks like, I have prepared a [short video](https://www.youtube.com/watch?v=qlDNLSrTvl8).

* Added an "Add Gradient" button under the enabled gradients list in the config panel. When clicked, it populates the gradient editor with a new gradient and opens the editor panel.
* Added a new modal window with UI controls for editing gradients.
  * The name field offers a public facing name for the gradient.
  * The colors table allows the user to add as many color stops as needed. Each row has:
    * A color input, for using a color picker to select the color.
    * A text input to set the hex color value.
    * A position field to adjust the color stop position.
    * An "add gradient" button. When clicked, a new color stop is added to the `currentGradient` object, and the colors table is rerendered. The position is automatically determined from the midpoint between its previous color stop and the next color stop.
    * A "remove gradient" button that removes the color stop from the `currentGradient` object and rerenders the colors table. If there are only two colors in the gradient, this button is disabled.
  * A checkbox to allow the gradient to show horizontally.
  * A color picker to adjust the background color.
* Custom gradients are added to the enabled gradients list. When a custom gradient in that list is clicked, the gradient editor is populated with a clone of the selected gradient for editing.
* When the save button is clicked in the gradient editor:
  * The saved gradient is assigned to the global `gradients` object. If the gradient is a new gradient, the key is generated uniquely. If the gradient is being edited, we keep track of the key in the `currentGradient` object and the gradient in the global `gradients` object is overwritten.
  * The gradient combo box in the settings panel is repopulated.
  * The enabled gradients list in the config panel is repopulated.
  * The gradient is registered to the analyzer.
  * Custom gradients are saved to local storage to be loaded across sessions.
* If the gradient editor has loaded an existing gradient, a delete button is available. When clicked:
  * The gradient is removed from the global `gradients` object.
  * The gradient combo box is repopulated.
  * The enabled gradients list is repopulated.
  * If the deleted gradient is the only enabled gradient, we automatically select the first gradient in the `gradients` object to be enabled.
  * The custom gradients are updated in local storage.